### PR TITLE
add toArray helper (prevents slice de-optimization)

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -1,3 +1,16 @@
+function toArray (args) {
+  var arr = []
+  var index = 0
+  var max = args.length
+
+  while (index < max) {
+    arr.push(args[index])
+    index++
+  }
+
+  return arr
+}
+
 function next (args) {
   args.length > 0 && args.shift().apply(this, args)
 }
@@ -9,7 +22,7 @@ function run (cb, args) {
 
 function tarry (cb, delay) {
   return function () {
-    var args = [].slice.call(arguments)
+    var args = toArray(arguments)
     var override = args[0]
 
     if (typeof override === 'number') {
@@ -27,7 +40,7 @@ function tarry (cb, delay) {
 }
 
 function queue () {
-  var args = [].slice.call(arguments)
+  var args = toArray(arguments)
   return tarry(function () {
     next(args.slice(0))
   })


### PR DESCRIPTION
Hey bud - cool lib.  Weird thing I came across in the past - using `slice` to convert `arguments` to an array de-optimizes V8.  More about it [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments), relevant part pictured below:

<img width="689" alt="screen shot 2017-08-18 at 4 42 12 pm" src="https://user-images.githubusercontent.com/2293641/29477031-97eca598-8434-11e7-850c-632ca6d256db.png">

To address this, I just added a simple `toArray` helper, and replaced the instance of `[].slice.call` with it.  Kept with your style (standard & ES5).  